### PR TITLE
Issue with 'Test-DscParameterState'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Renamed 'Test-DscParameterState' to 'Test-DscParameterState2' for a conflict with 'DscResource.Common'.
+
 ### Added
 
 - Migrated the resource to Sampler

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -9,7 +9,7 @@
 
     InvokeBuild                 = 'latest'
     PSScriptAnalyzer            = 'latest'
-    Pester                      = 'latest'
+    Pester                      = '4.10.1'
     Plaster                     = 'latest'
     ModuleBuilder               = 'latest'
     ChangelogManagement         = 'latest'
@@ -20,5 +20,4 @@
     'DscResource.DocGenerator'  = 'latest'
     'DscResource.Common'        = 'latest'
     xDscResourceDesigner        = 'latest'
-    PSPKI                       = 'latest'
 }

--- a/source/DSCClassResources/JeaRoleCapabilities/JeaRoleCapabilities.psm1
+++ b/source/DSCClassResources/JeaRoleCapabilities/JeaRoleCapabilities.psm1
@@ -245,7 +245,7 @@ class JeaRoleCapabilities
                 }
             }
 
-            $compare = Test-DscParameterState -CurrentValues $currentState -DesiredValues $Parameters -SortArrayValues -TurnOffTypeChecking -ReverseCheck
+            $compare = Test-DscParameterState2 -CurrentValues $currentState -DesiredValues $Parameters -SortArrayValues -TurnOffTypeChecking -ReverseCheck
 
             return $compare
         }

--- a/source/DSCClassResources/JeaSessionConfiguration/JeaSessionConfiguration.psm1
+++ b/source/DSCClassResources/JeaSessionConfiguration/JeaSessionConfiguration.psm1
@@ -270,7 +270,7 @@ class JeaSessionConfiguration
             }
         }
 
-        $compare = Test-DscParameterState -CurrentValues $currentState -DesiredValues $parameters -TurnOffTypeChecking -SortArrayValues -ReverseCheck
+        $compare = Test-DscParameterState2 -CurrentValues $currentState -DesiredValues $parameters -TurnOffTypeChecking -SortArrayValues -ReverseCheck
 
         return $compare
     }

--- a/source/Modules/JeaDsc.Common/JeaDsc.Common.psm1
+++ b/source/Modules/JeaDsc.Common/JeaDsc.Common.psm1
@@ -682,7 +682,7 @@ function Convert-StringToObject
     }
 }
 
-function Test-DscParameterState
+function Test-DscParameterState2
 {
     [CmdletBinding()]
     param
@@ -967,11 +967,11 @@ function Test-DscParameterState
 
                         if ($returnValue)
                         {
-                            $returnValue = Test-DscParameterState @param
+                            $returnValue = Test-DscParameterState2 @param
                         }
                         else
                         {
-                            Test-DscParameterState @param | Out-Null
+                            Test-DscParameterState2 @param | Out-Null
                         }
                         continue
                     }
@@ -1000,11 +1000,11 @@ function Test-DscParameterState
 
             if ($returnValue)
             {
-                $returnValue = Test-DscParameterState @param
+                $returnValue = Test-DscParameterState2 @param
             }
             else
             {
-                Test-DscParameterState @param | Out-Null
+                Test-DscParameterState2 @param | Out-Null
             }
             continue
         }
@@ -1054,11 +1054,11 @@ function Test-DscParameterState
 
         if ($returnValue)
         {
-            $returnValue = Test-DscParameterState @reverseCheckParameters
+            $returnValue = Test-DscParameterState2 @reverseCheckParameters
         }
         else
         {
-            $null = Test-DscParameterState @reverseCheckParameters
+            $null = Test-DscParameterState2 @reverseCheckParameters
         }
     }
 

--- a/source/Modules/JeaDsc.Common/en-us/JeaDsc.Common.strings.psd1
+++ b/source/Modules/JeaDsc.Common/en-us/JeaDsc.Common.strings.psd1
@@ -1,8 +1,8 @@
 # Localized resources for JeaDsc
 
 ConvertFrom-StringData @'
-    InvalidCurrentValuesError            = Property 'CurrentValues' in Test-DscParameterState must be either a Hashtable, CimInstance or CimIntance[]. Type detected was '{0}'.
-    InvalidDesiredValuesError            = Property 'DesiredValues' in Test-DscParameterState must be either a Hashtable or CimInstance. Type detected was '{0}'.
+    InvalidCurrentValuesError            = Property 'CurrentValues' in Test-DscParameterState2 must be either a Hashtable, CimInstance or CimIntance[]. Type detected was '{0}'.
+    InvalidDesiredValuesError            = Property 'DesiredValues' in Test-DscParameterState2 must be either a Hashtable or CimInstance. Type detected was '{0}'.
     InvalidValuesToCheckError            = If 'DesiredValues' is a CimInstance then property 'ValuesToCheck' must contain a value.
     TestDscParameterCompareMessage       = Comparing values in property '{0}'.
     MatchPsCredentialUsernameMessage     = MATCH: PSCredential username match. Current state is '{0}' and desired state is '{1}'.


### PR DESCRIPTION
#### Pull Request (PR) description
'Test-DscParameterState' is defined in 'JeaDsc.Common' and 'DscResource.Common' which leads to a conflict. 'Test-DscParameterState' was renamed to 'Test-DscParameterState2'.

Pester version was changed from latest to 4.10.1.

Removed dependency to PSPKI module as it was not required.

#### This Pull Request (PR) fixes the following issues
Fixes #35

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/jeadsc/36)
<!-- Reviewable:end -->
