### PR TITLE
JeaSessionConfiguration: Fixing RunAsVirtualAccount is always set to 'true'

### DIFF
--- a/source/Classes/1.SessionConfigurationUtility.ps1
+++ b/source/Classes/1.SessionConfigurationUtility.ps1
@@ -19,7 +19,7 @@ class SessionConfigurationUtility
             throw $script:localizedDataSession.ConflictRunAsVirtualAccountAndGroupManagedServiceAccount
         }
 
-        if (-not $this.GroupManagedServiceAccount)
+        if (-not $this.GroupManagedServiceAccount -and $null -eq $this.RunAsVirtualAccount)
         {
             $this.RunAsVirtualAccount = $true
             Write-Warning -Message $script:localizedDataSession.NotDefinedGMSaAndVirtualAccount

--- a/source/Classes/JeaSessionConfiguration.ps1
+++ b/source/Classes/JeaSessionConfiguration.ps1
@@ -18,7 +18,7 @@ class JeaSessionConfiguration:SessionConfigurationUtility
 
     ## run the endpoint under a Virtual Account
     [DscProperty()]
-    [bool] $RunAsVirtualAccount
+    [nullable[bool]] $RunAsVirtualAccount
 
     ## The optional groups to be used when the endpoint is configured to
     ## run as a Virtual Account


### PR DESCRIPTION
#### Pull Request (PR) description
The bool parameter 'RunAsVirtualAccount' was always set to 'true' even when it's defined as 'false' and displays the warning message ''GroupManagedServiceAccount' and 'RunAsVirtualAccount' are not defined, setting 'RunAsVirtualAccount' to 'true'.

This should be fixed by making the boolean nullable and evaluate if it's set.

#### This Pull Request (PR) fixes the following issues
None

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/jeadsc/48)
<!-- Reviewable:end -->
